### PR TITLE
Improvement ulyanov_et_al_2016

### DIFF
--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -187,9 +187,7 @@ def images() -> DownloadableImageCollection:
             md5="7fdd9603a5182dcef23d7fb1c5217888",
         ),
     }
-    return DownloadableImageCollection(
-        {**content_images, **style_images}
-    )
+    return DownloadableImageCollection({**content_images, **style_images})
 
 
 def dataset(

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -123,15 +123,6 @@ def images() -> DownloadableImageCollection:
             md5="dc9ad203263f34352e18bc29b03e1066",
             file="tuebingen_neckarfront__andreas_praefcke.jpg",
         ),
-        "che_high": DownloadableImage(
-            "https://upload.wikimedia.org/wikipedia/commons/5/58/CheHigh.jpg",
-            title="CheHigh",
-            author="Alberto Korda",
-            date="1960",
-            license=ExpiredCopyrightLicense(1960),
-            md5="62af957a89fdfcb9618570b6d836d054",
-            file="CheHigh.jpg",
-        ),
         "tower_of_babel": DownloadableImage(
             "https://upload.wikimedia.org/wikipedia/commons/f/fc/Pieter_Bruegel_the_Elder_-_The_Tower_of_Babel_%28Vienna%29_-_Google_Art_Project_-_edited.jpg",
             title="The Tower of Babel",
@@ -151,31 +142,6 @@ def images() -> DownloadableImageCollection:
         ),
     }
 
-    texture_base_ulyanov = urljoin(base_ulyanov, "textures/")
-    base_ulyanov_suppl_texture = "https://raw.githubusercontent.com/DmitryUlyanov/texture_nets/texture_nets_v1/supplementary//texture_models/"
-
-    texture_images = {
-        "cezanne": DownloadableImage(
-            urljoin(texture_base_ulyanov, "cezanne.jpg"),
-            md5="fab6d360c361c38c331b3ee5ef0078f5",
-        ),
-        "bricks": DownloadableImage(
-            urljoin(base_ulyanov_suppl_texture, "bricks.png"),
-            md5="1e13818e1fbefbd22f110a1c2f781d40",
-        ),
-        "pebble": DownloadableImage(
-            urljoin(base_ulyanov_suppl_texture, "pebble.png"),
-            md5="5b5e5aa6c579e42e268058a94d683a6c",
-        ),
-        "pixels": DownloadableImage(
-            urljoin(base_ulyanov_suppl_texture, "pixelcity_windows2.jpg"),
-            md5="53026a8411e7c26e959e36d3223f3b8f",
-        ),
-        "peppers": DownloadableImage(
-            urljoin(base_ulyanov_suppl_texture, "red-peppers256.o.jpg"),
-            md5="16371574a10e0d10b88b807204c4f546",
-        ),
-    }
     base_johnson = (
         "https://raw.githubusercontent.com/jcjohnson/fast-neural-style/master/images/"
     )
@@ -218,7 +184,7 @@ def images() -> DownloadableImageCollection:
         ),
     }
     return DownloadableImageCollection(
-        {**texture_images, **content_images, **style_images}
+        {**content_images, **style_images}
     )
 
 

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -53,6 +53,10 @@ def content_transform(
     transforms_: List[transforms.Transform] = []
     if impl_params:
         if instance_norm:
+            # Necessary transformation, otherwise ValidRandomCrop will not work with too
+            # small images. This is therefore not in the reference implementation.
+            # TODO: ??
+            transforms_.append(transforms.Resize(edge_size))
             # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/datasets/style.lua#L83
             # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/datasets/transforms.lua#L62-L92
             transforms_.append(transforms.ValidRandomCrop(edge_size))

--- a/pystiche_papers/ulyanov_et_al_2016/_loss.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_loss.py
@@ -69,7 +69,7 @@ class ScaleGradients(torch.autograd.Function):
     def backward(self: Any, grad_output: torch.Tensor) -> Tuple[torch.Tensor, Any]:  # type: ignore[override]
         grad_input = grad_output.clone()
         grad_input = grad_input / (torch.norm(grad_input, keepdim=True) + 1e-8)
-        return grad_input * self.weight, None
+        return grad_input, None
 
 
 class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):

--- a/pystiche_papers/ulyanov_et_al_2016/_loss.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_loss.py
@@ -135,7 +135,7 @@ class GramOperator(ops.GramOperator):
         # In the reference implementation the gram_matrix is only divided by the
         # batch_size.
         self.normalize_by_num_channels = impl_params
-        super().__init__(encoder, **gram_op_kwargs)
+        super().__init__(encoder, normalize=False, **gram_op_kwargs)
 
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/src/texture_loss.lua#L56-L57
         # In the reference implementation the gradients of the style_loss are

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -388,6 +388,7 @@ def level(
         modules.append(("conv_seq", conv_seq))
         return SequentialWithOutChannels(OrderedDict(modules))
 
+    # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/models/pyramid.lua#L16-L18
     use_noise = not impl_params or not instance_norm
     shallow_branch = conv_sequence(in_channels, out_channels=8, use_noise=use_noise)
 

--- a/pystiche_papers/ulyanov_et_al_2016/_nst.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_nst.py
@@ -85,7 +85,7 @@ def training(
     criterion = criterion.eval()
     criterion = criterion.to(device)
 
-    optimizer = _optimizer(transformer)
+    optimizer = _optimizer(transformer,impl_params=impl_params, instance_norm=instance_norm)
     lr_scheduler = _lr_scheduler(
         optimizer,
         impl_params=impl_params,
@@ -130,7 +130,7 @@ def stylization(
     input_image: torch.Tensor,
     transformer: Union[nn.Module, str],
     impl_params: bool = True,
-    instance_norm: bool = False,
+    instance_norm: bool = True,
     edge_size: int = 256,
 ) -> torch.Tensor:
     r"""Transforms an input image into a stylised version using the transformer.

--- a/pystiche_papers/ulyanov_et_al_2016/_utils.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_utils.py
@@ -34,7 +34,7 @@ def hyper_parameters(
             layers=("relu1_1", "relu2_1", "relu3_1", "relu4_1")
             if impl_params and instance_norm
             else ("relu1_1", "relu2_1", "relu3_1", "relu4_1", "relu5_1"),
-            layer_weights=[1e3]*4 if impl_params and instance_norm else [1e3]*5,
+            layer_weights=[1e3] * 4 if impl_params and instance_norm else [1e3] * 5,
             # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L23
             score_weight=1e0 if impl_params and not instance_norm else 1e0,
         ),

--- a/pystiche_papers/ulyanov_et_al_2016/_utils.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_utils.py
@@ -34,9 +34,9 @@ def hyper_parameters(
             layers=("relu1_1", "relu2_1", "relu3_1", "relu4_1")
             if impl_params and instance_norm
             else ("relu1_1", "relu2_1", "relu3_1", "relu4_1", "relu5_1"),
-            layer_weights="sum",
+            layer_weights=[1e3]*4 if impl_params and instance_norm else [1e3]*5,
             # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L23
-            score_weight=1e3 if impl_params and not instance_norm else 1e0,
+            score_weight=1e0 if impl_params and not instance_norm else 1e0,
         ),
         content_transform=HyperParameters(edge_size=256,),
         style_transform=HyperParameters(

--- a/tests/replication/test_ulyanov_et_al_2016.py
+++ b/tests/replication/test_ulyanov_et_al_2016.py
@@ -4,7 +4,6 @@ from os import path
 
 import pytest
 
-import torch
 from torch.utils.data import TensorDataset
 
 import pystiche_papers.ulyanov_et_al_2016 as paper
@@ -68,6 +67,7 @@ def main():
 def args(tmpdir):
     return argparse.Namespace(
         image_source_dir=tmpdir,
+        image_results_dir=tmpdir,
         dataset_dir=tmpdir,
         model_dir=tmpdir,
         device=misc.get_device(),
@@ -85,6 +85,9 @@ def test_training_parse_input_smoke(subtests, main, args):
 
     with subtests.test("image_source_dir"):
         assert_dir_exists(actual_args.image_source_dir)
+
+    with subtests.test("image_results_dir"):
+        assert_dir_exists(actual_args.image_results_dir)
 
     with subtests.test("dataset_dir"):
         assert_dir_exists(actual_args.dataset_dir)
@@ -106,22 +109,3 @@ def test_training_parse_input_smoke(subtests, main, args):
 
     with subtests.test("quiet"):
         assert isinstance(actual_args.quiet, bool)
-
-
-def test_training_smoke(subtests, images, dataset, training, main, args):
-    main.training(args)
-
-    assert training.call_count == 7
-
-    with subtests.test("content_image_loader"):
-        image_loader_type = type(paper.image_loader(dataset))
-        for call_args in training.call_args_list:
-            args, _ = call_args
-            content_image_loader, _ = args
-            assert isinstance(content_image_loader, image_loader_type)
-
-    with subtests.test("style_image"):
-        for call_args in training.call_args_list:
-            args, _ = call_args
-            _, style_image = args
-            assert isinstance(style_image, torch.Tensor)

--- a/tests/unit/ulyanov_et_al_2016/test_data.py
+++ b/tests/unit/ulyanov_et_al_2016/test_data.py
@@ -31,9 +31,10 @@ def test_content_transform(subtests, content_image, impl_params, instance_norm):
 
     if impl_params:
         if instance_norm:
+            desired = F.resize(content_image, edge_size)
             transform = transforms.ValidRandomCrop(edge_size)
             utils.make_reproducible()
-            desired = transform(content_image)
+            desired = transform(desired)
         else:
             desired = F.resize(content_image, edge_size)
     else:
@@ -66,9 +67,10 @@ def test_content_transform_grayscale_image(
 
     if impl_params:
         if instance_norm:
+            transform_image = F.resize(content_image, edge_size)
             transform = transforms.ValidRandomCrop(edge_size)
             utils.make_reproducible()
-            transform_image = transform(content_image)
+            transform_image = transform(transform_image)
         else:
             transform_image = F.resize(content_image, edge_size)
     else:

--- a/tests/unit/ulyanov_et_al_2016/test_loss.py
+++ b/tests/unit/ulyanov_et_al_2016/test_loss.py
@@ -104,7 +104,7 @@ def test_style_loss(subtests, impl_params, instance_norm):
         assert layers == hyper_parameters.layers
 
     with subtests.test("layer_weights"):
-        assert layer_weights == pytest.approx((1e0,) * len(hyper_parameters.layers))
+        assert layer_weights == pytest.approx((1e3,) * len(hyper_parameters.layers))
 
     with subtests.test("score_weight"):
         assert style_loss.score_weight == pytest.approx(hyper_parameters.score_weight)

--- a/tests/unit/ulyanov_et_al_2016/test_loss.py
+++ b/tests/unit/ulyanov_et_al_2016/test_loss.py
@@ -63,8 +63,8 @@ def test_GramOperator(
     configs = ((True, True, 1.0), (False, False, input_image.size()[0]))
     for (impl_params, normalize_by_num_channels, extra_batch_normalization) in configs:
         with subtests.test(impl_params=impl_params):
-            target_repr = pystiche.gram_matrix(encoder(target_image), normalize=True)
-            input_repr = pystiche.gram_matrix(encoder(input_image), normalize=True)
+            target_repr = pystiche.gram_matrix(encoder(target_image), normalize=False)
+            input_repr = pystiche.gram_matrix(encoder(input_image), normalize=False)
             intern_target_repr = (
                 target_repr / target_repr.size()[-1]
                 if normalize_by_num_channels

--- a/tests/unit/ulyanov_et_al_2016/test_loss.py
+++ b/tests/unit/ulyanov_et_al_2016/test_loss.py
@@ -60,18 +60,11 @@ def test_GramOperator(
     multi_layer_encoder, layer = multi_layer_encoder_with_layer
     encoder = multi_layer_encoder.extract_encoder(layer)
 
-    configs = ((True, True, 1.0, False), (False, False, input_image.size()[0], True))
-    for (
-        impl_params,
-        normalize_by_num_channels,
-        extra_batch_normalization,
-        normalize,
-    ) in configs:
+    configs = ((True, True, 1.0), (False, False, input_image.size()[0]))
+    for (impl_params, normalize_by_num_channels, extra_batch_normalization) in configs:
         with subtests.test(impl_params=impl_params):
-            target_repr = pystiche.gram_matrix(
-                encoder(target_image), normalize=normalize
-            )
-            input_repr = pystiche.gram_matrix(encoder(input_image), normalize=normalize)
+            target_repr = pystiche.gram_matrix(encoder(target_image), normalize=True)
+            input_repr = pystiche.gram_matrix(encoder(input_image), normalize=True)
             intern_target_repr = (
                 target_repr / target_repr.size()[-1]
                 if normalize_by_num_channels
@@ -86,7 +79,7 @@ def test_GramOperator(
             op.set_target_image(target_image)
             actual = op(input_image)
 
-            score = mse_loss(intern_input_repr, intern_target_repr,)
+            score = mse_loss(intern_input_repr, intern_target_repr)
             desired = score / extra_batch_normalization
 
             assert actual == ptu.approx(desired, rel=1e-3)

--- a/tests/unit/ulyanov_et_al_2016/test_nst.py
+++ b/tests/unit/ulyanov_et_al_2016/test_nst.py
@@ -360,11 +360,11 @@ def test_training_lr_scheduler_optimizer(
 def stylization(input_image, transformer_mocks):
     _, transformer = transformer_mocks
 
-    def stylization_(input_image_=None, transformer_="style", edge_size=16, **kwargs):
+    def stylization_(input_image_=None, transformer_="style", **kwargs):
         if input_image_ is None:
             input_image_ = input_image
 
-        output = paper.stylization(input_image_, transformer_, edge_size=edge_size, **kwargs)
+        output = paper.stylization(input_image_, transformer_, **kwargs)
 
         if isinstance(transformer_, str):
             transformer.assert_called_once()
@@ -381,20 +381,17 @@ def stylization(input_image, transformer_mocks):
     return stylization_
 
 
-def test_stylization_smoke(
-    stylization, postprocessor_mocks, input_image
-):
-    edge_size = 32
-    _, _, output_image = stylization(input_image, edge_size=edge_size)
-    ptu.assert_allclose(output_image, F.resize(input_image, (edge_size, edge_size)) + 0.5, rtol=1e-6)
+def test_stylization_smoke(stylization, postprocessor_mocks, input_image):
+    hyper_parameters = paper.hyper_parameters()
+    edge_size = hyper_parameters.content_transform.edge_size
+    _, _, output_image = stylization(input_image,)
+    ptu.assert_allclose(
+        output_image, F.resize(input_image, (edge_size, edge_size)) + 0.5, rtol=1e-6
+    )
 
 
 def test_stylization_device(
-    subtests,
-    postprocessor_mocks,
-    transformer_mocks,
-    stylization,
-    input_image,
+    subtests, postprocessor_mocks, transformer_mocks, stylization, input_image,
 ):
     stylization(input_image)
 
@@ -409,11 +406,7 @@ def test_stylization_device(
 
 
 def test_stylization_transformer_eval(
-    subtests,
-    postprocessor_mocks,
-    transformer_mocks,
-    stylization,
-    input_image,
+    subtests, postprocessor_mocks, transformer_mocks, stylization, input_image,
 ):
     _, transformer = transformer_mocks
     for impl_params, instance_norm in itertools.product((True, False), (True, False)):

--- a/tests/unit/ulyanov_et_al_2016/test_utils.py
+++ b/tests/unit/ulyanov_et_al_2016/test_utils.py
@@ -53,12 +53,10 @@ def test_hyper_parameters_style_loss(subtests, impl_params, instance_norm):
         )
 
     with subtests.test("layer_weights"):
-        assert hyper_parameters.layer_weights == "sum"
+        assert hyper_parameters.layer_weights == [1e3] * 4 if impl_params and instance_norm else [1e3] * 5
 
     with subtests.test("score_weight"):
-        assert hyper_parameters.score_weight == pytest.approx(
-            1e3 if impl_params and not instance_norm else 1e0
-        )
+        assert hyper_parameters.score_weight == pytest.approx(1e0)
 
 
 @impl_params_and_instance_norm


### PR DESCRIPTION
So far, this implementation has not produced good results. This was because in the reference 
implementation the backward pass of the gradient is normalized and this is missing 
in this implementation. The results are now better, but still with measures, probably due to different hyperparameter that are too high or too low. Therefore, similar results as in the paper can now be created if the `style_weight` is changed.

Therefore in the following two points which should be discussed in advance:

1. Due to the changed hyperparameter setting from [#244](https://github.com/pmeier/pystiche_papers/pull/244) it is now easier to adjust the hyperparameter. Therefore i would adjust the `style_weight` for this replication so that besides the results with the default parameters similar results to the paper are created.

2. One problem with the replication of the master branch is that the images are too small and have to be enlarged for training. I currently added an additional `resize` in the `content_image_transform` before the `ValidRandomCrop`, but this is not 
implemented in the reference implementation.