### PR TITLE
Correct Gatys ecker bethge 2016 Figure 3 bug

### DIFF
--- a/replication/gatys_ecker_bethge_2016/main.py
+++ b/replication/gatys_ecker_bethge_2016/main.py
@@ -80,9 +80,7 @@ def figure_3(args):
     for layers, score_weight in itertools.product(layer_configs, score_weights):
         row_label = layers[-1]
         column_label = f"{1.0 / score_weight:.0e}"
-        header = (
-            f"Replicating Figure 3 image in row {row_label} and column {column_label}  with {params} parameters"
-        )
+        header = f"Replicating Figure 3 image in row {row_label} and column {column_label}  with {params} parameters"
         with args.logger.environment(header):
             hyper_parameters.style_loss.layers = layers
             if args.impl_params:


### PR DESCRIPTION
Currently, the same style layers are always used in Figure 3 instead of the layers to be looped over. This PR corrects this by using the correct layers for the nst. Additionally, the layers from hyperparameter are used to switch the mapping between impl_param and the paper.