### PR TITLE
Change output filenames in replication scripts

### DIFF
--- a/pystiche_papers/utils/misc.py
+++ b/pystiche_papers/utils/misc.py
@@ -40,6 +40,7 @@ __all__ = [
     "str_to_bool",
     "load_urls_from_csv",
     "select_url_from_csv",
+    "make_output_filename",
 ]
 
 
@@ -238,3 +239,9 @@ def select_url_from_csv(
             f"{fieldname}: {value}" for fieldname, value in zip(fieldnames, config)
         )
         raise RuntimeError(msg) from error
+
+
+def make_output_filename(name_parts: List[str], impl_params: bool = True, extension: str = ".jpg") -> str:
+    if impl_params:
+        name_parts.append("impl_params")
+    return "__".join(name_parts) + extension

--- a/pystiche_papers/utils/misc.py
+++ b/pystiche_papers/utils/misc.py
@@ -242,14 +242,8 @@ def select_url_from_csv(
 
 
 def make_output_filename(
-    name_parts: List[str],
-    impl_params: bool = True,
-    instance_norm: bool = False,
+    *parts: str,
     extension: str = ".jpg",
+    **flags: bool,
 ) -> str:
-    if impl_params:
-        name_parts.append("impl_params")
-
-    if instance_norm:
-        name_parts.append("instance_norm")
-    return "__".join(name_parts) + extension
+    return "__".join([*parts, *[name for name, flag in flags.items() if flag]]) + extension

--- a/pystiche_papers/utils/misc.py
+++ b/pystiche_papers/utils/misc.py
@@ -241,7 +241,9 @@ def select_url_from_csv(
         raise RuntimeError(msg) from error
 
 
-def make_output_filename(name_parts: List[str], impl_params: bool = True, extension: str = ".jpg") -> str:
+def make_output_filename(
+    name_parts: List[str], impl_params: bool = True, extension: str = ".jpg"
+) -> str:
     if impl_params:
         name_parts.append("impl_params")
     return "__".join(name_parts) + extension

--- a/pystiche_papers/utils/misc.py
+++ b/pystiche_papers/utils/misc.py
@@ -242,8 +242,14 @@ def select_url_from_csv(
 
 
 def make_output_filename(
-    name_parts: List[str], impl_params: bool = True, extension: str = ".jpg"
+    name_parts: List[str],
+    impl_params: bool = True,
+    instance_norm: bool = False,
+    extension: str = ".jpg",
 ) -> str:
     if impl_params:
         name_parts.append("impl_params")
+
+    if instance_norm:
+        name_parts.append("instance_norm")
     return "__".join(name_parts) + extension

--- a/replication/gatys_ecker_bethge_2016/main.py
+++ b/replication/gatys_ecker_bethge_2016/main.py
@@ -51,10 +51,14 @@ def figure_2(args):
             impl_params=args.impl_params,
             hyper_parameters=hyper_parameters,
         )
+        filename = utils.make_output_filename(
+            ["gatys_ecker_betghe_2016", "fig_2", style_image.label],
+            impl_params=args.impl_params
+        )
 
         save_result(
             output_image,
-            path.join(args.image_results_dir, f"fig_2__{style_image.label}.jpg"),
+            path.join(args.image_results_dir, filename),
         )
 
 
@@ -99,10 +103,14 @@ def figure_3(args):
             hyper_parameters=hyper_parameters,
         )
 
+        filename = utils.make_output_filename(
+            ["gatys_ecker_betghe_2016", "fig_3", row_label, column_label],
+            impl_params=args.impl_params
+        )
         save_result(
             output_image,
             path.join(
-                args.image_results_dir, f"fig_3__{row_label}__{column_label}.jpg"
+                args.image_results_dir, filename
             ),
         )
 
@@ -142,5 +150,5 @@ def parse_input():
 if __name__ == "__main__":
     args = parse_input()
 
-    # figure_2(args)
+    figure_2(args)
     figure_3(args)

--- a/replication/gatys_ecker_bethge_2016/main.py
+++ b/replication/gatys_ecker_bethge_2016/main.py
@@ -53,7 +53,7 @@ def figure_2(args):
         )
         filename = utils.make_output_filename(
             ["gatys_ecker_betghe_2016", "fig_2", style_image.label],
-            impl_params=args.impl_params
+            impl_params=args.impl_params,
         )
         save_result(
             output_image,
@@ -104,13 +104,11 @@ def figure_3(args):
 
         filename = utils.make_output_filename(
             ["gatys_ecker_betghe_2016", "fig_3", row_label, column_label],
-            impl_params=args.impl_params
+            impl_params=args.impl_params,
         )
         save_result(
             output_image,
-            path.join(
-                args.image_results_dir, filename
-            ),
+            path.join(args.image_results_dir, filename),
         )
 
 

--- a/replication/gatys_ecker_bethge_2016/main.py
+++ b/replication/gatys_ecker_bethge_2016/main.py
@@ -52,7 +52,7 @@ def figure_2(args):
             hyper_parameters=hyper_parameters,
         )
         filename = utils.make_output_filename(
-            ["gatys_ecker_betghe_2016", "fig_2", style_image.label],
+            "gatys_ecker_betghe_2016", "fig_2", style_image.label,
             impl_params=args.impl_params,
         )
         save_result(

--- a/replication/gatys_ecker_bethge_2016/main.py
+++ b/replication/gatys_ecker_bethge_2016/main.py
@@ -52,7 +52,9 @@ def figure_2(args):
             hyper_parameters=hyper_parameters,
         )
         filename = utils.make_output_filename(
-            "gatys_ecker_betghe_2016", "fig_2", style_image.label,
+            "gatys_ecker_betghe_2016",
+            "fig_2",
+            style_image.label,
             impl_params=args.impl_params,
         )
         save_result(
@@ -103,7 +105,10 @@ def figure_3(args):
         )
 
         filename = utils.make_output_filename(
-            ["gatys_ecker_betghe_2016", "fig_3", row_label, column_label],
+            "gatys_ecker_betghe_2016",
+            "fig_3",
+            row_label,
+            column_label,
             impl_params=args.impl_params,
         )
         save_result(

--- a/replication/gatys_ecker_bethge_2016/main.py
+++ b/replication/gatys_ecker_bethge_2016/main.py
@@ -55,7 +55,6 @@ def figure_2(args):
             ["gatys_ecker_betghe_2016", "fig_2", style_image.label],
             impl_params=args.impl_params
         )
-
         save_result(
             output_image,
             path.join(args.image_results_dir, filename),

--- a/replication/gatys_et_al_2017/main.py
+++ b/replication/gatys_et_al_2017/main.py
@@ -31,7 +31,10 @@ def figure_2(args):
             impl_params=args.impl_params,
         )
         filename = make_output_filename(
-            "gatys_et_al_2017", "fig_2", "d", impl_params=args.impl_params
+            "gatys_et_al_2017", 
+            "fig_2", 
+            "d", 
+            impl_params=args.impl_params,
         )
 
         output_file = path.join(args.image_results_dir, filename)

--- a/replication/gatys_et_al_2017/main.py
+++ b/replication/gatys_et_al_2017/main.py
@@ -8,7 +8,7 @@ from torchvision.transforms.functional import resize, rgb_to_grayscale
 import pystiche_papers.gatys_et_al_2017 as paper
 from pystiche.image import write_image
 from pystiche.misc import get_device
-from pystiche_papers.utils import abort_if_cuda_memory_exausts
+from pystiche_papers.utils import abort_if_cuda_memory_exausts, make_output_filename
 
 
 def read_image_and_guides(image, **read_kwargs):
@@ -30,8 +30,10 @@ def figure_2(args):
             style_image,
             impl_params=args.impl_params,
         )
+        filename = make_output_filename(["gatys_et_al_2017", "fig_2", "d"],
+                                        impl_params=args.impl_params)
 
-        output_file = path.join(args.image_results_dir, "fig_2__d.jpg")
+        output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
 
     @abort_if_cuda_memory_exausts
@@ -58,8 +60,12 @@ def figure_2(args):
             style_images_and_guides,
             impl_params=args.impl_params,
         )
+        filename = make_output_filename(
+            ["gatys_et_al_2017", "fig_2", label],
+            impl_params=args.impl_params
+        )
 
-        output_file = path.join(args.image_results_dir, f"fig_2__{label}.jpg")
+        output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
 
     images = paper.images()
@@ -147,8 +153,12 @@ def figure_3(args):
             style_image,
             impl_params=args.impl_params,
         )
+        filename = make_output_filename(
+            ["gatys_et_al_2017", "fig_3", "c"],
+            impl_params=args.impl_params
+        )
 
-        output_file = path.join(args.image_results_dir, "fig_3__c.jpg")
+        output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
 
     @abort_if_cuda_memory_exausts
@@ -169,8 +179,11 @@ def figure_3(args):
         output_chromaticity = resize(content_chromaticity, output_luminance.size()[2:])
         output_image_yuv = torch.cat((output_luminance, output_chromaticity), dim=1)
         output_image = yuv_to_rgb(output_image_yuv)
-
-        output_file = path.join(args.image_results_dir, "fig_3__d.jpg")
+        filename = make_output_filename(
+            ["gatys_et_al_2017", "fig_3", "d"],
+            impl_params=args.impl_params
+        )
+        output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
 
     @abort_if_cuda_memory_exausts
@@ -183,8 +196,11 @@ def figure_3(args):
             style_image,
             impl_params=args.impl_params,
         )
-
-        output_file = path.join(args.image_results_dir, "fig_3__e.jpg")
+        filename = make_output_filename(
+            ["gatys_et_al_2017", "fig_3", "e"],
+            impl_params=args.impl_params
+        )
+        output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
 
     images = paper.images()

--- a/replication/gatys_et_al_2017/main.py
+++ b/replication/gatys_et_al_2017/main.py
@@ -157,7 +157,6 @@ def figure_3(args):
             ["gatys_et_al_2017", "fig_3", "c"],
             impl_params=args.impl_params
         )
-
         output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
 

--- a/replication/gatys_et_al_2017/main.py
+++ b/replication/gatys_et_al_2017/main.py
@@ -31,9 +31,9 @@ def figure_2(args):
             impl_params=args.impl_params,
         )
         filename = make_output_filename(
-            "gatys_et_al_2017", 
-            "fig_2", 
-            "d", 
+            "gatys_et_al_2017",
+            "fig_2",
+            "d",
             impl_params=args.impl_params,
         )
 
@@ -65,7 +65,10 @@ def figure_2(args):
             impl_params=args.impl_params,
         )
         filename = make_output_filename(
-            "gatys_et_al_2017", "fig_2", label, impl_params=args.impl_params
+            "gatys_et_al_2017",
+            "fig_2",
+            label,
+            impl_params=args.impl_params,
         )
         output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
@@ -156,7 +159,10 @@ def figure_3(args):
             impl_params=args.impl_params,
         )
         filename = make_output_filename(
-            "gatys_et_al_2017", "fig_3", "c", impl_params=args.impl_params
+            "gatys_et_al_2017",
+            "fig_3",
+            "c",
+            impl_params=args.impl_params,
         )
         output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
@@ -180,7 +186,10 @@ def figure_3(args):
         output_image_yuv = torch.cat((output_luminance, output_chromaticity), dim=1)
         output_image = yuv_to_rgb(output_image_yuv)
         filename = make_output_filename(
-            "gatys_et_al_2017", "fig_3", "d", impl_params=args.impl_params
+            "gatys_et_al_2017",
+            "fig_3",
+            "d",
+            impl_params=args.impl_params,
         )
         output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
@@ -196,7 +205,10 @@ def figure_3(args):
             impl_params=args.impl_params,
         )
         filename = make_output_filename(
-            "gatys_et_al_2017", "fig_3", "e", impl_params=args.impl_params
+            "gatys_et_al_2017",
+            "fig_3",
+            "e",
+            impl_params=args.impl_params,
         )
         output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)

--- a/replication/gatys_et_al_2017/main.py
+++ b/replication/gatys_et_al_2017/main.py
@@ -31,7 +31,7 @@ def figure_2(args):
             impl_params=args.impl_params,
         )
         filename = make_output_filename(
-            ["gatys_et_al_2017", "fig_2", "d"], impl_params=args.impl_params
+            "gatys_et_al_2017", "fig_2", "d", impl_params=args.impl_params
         )
 
         output_file = path.join(args.image_results_dir, filename)
@@ -62,7 +62,7 @@ def figure_2(args):
             impl_params=args.impl_params,
         )
         filename = make_output_filename(
-            ["gatys_et_al_2017", "fig_2", label], impl_params=args.impl_params
+            "gatys_et_al_2017", "fig_2", label, impl_params=args.impl_params
         )
         output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
@@ -153,7 +153,7 @@ def figure_3(args):
             impl_params=args.impl_params,
         )
         filename = make_output_filename(
-            ["gatys_et_al_2017", "fig_3", "c"], impl_params=args.impl_params
+            "gatys_et_al_2017", "fig_3", "c", impl_params=args.impl_params
         )
         output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
@@ -177,7 +177,7 @@ def figure_3(args):
         output_image_yuv = torch.cat((output_luminance, output_chromaticity), dim=1)
         output_image = yuv_to_rgb(output_image_yuv)
         filename = make_output_filename(
-            ["gatys_et_al_2017", "fig_3", "d"], impl_params=args.impl_params
+            "gatys_et_al_2017", "fig_3", "d", impl_params=args.impl_params
         )
         output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
@@ -193,7 +193,7 @@ def figure_3(args):
             impl_params=args.impl_params,
         )
         filename = make_output_filename(
-            ["gatys_et_al_2017", "fig_3", "e"], impl_params=args.impl_params
+            "gatys_et_al_2017", "fig_3", "e", impl_params=args.impl_params
         )
         output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)

--- a/replication/gatys_et_al_2017/main.py
+++ b/replication/gatys_et_al_2017/main.py
@@ -30,8 +30,9 @@ def figure_2(args):
             style_image,
             impl_params=args.impl_params,
         )
-        filename = make_output_filename(["gatys_et_al_2017", "fig_2", "d"],
-                                        impl_params=args.impl_params)
+        filename = make_output_filename(
+            ["gatys_et_al_2017", "fig_2", "d"], impl_params=args.impl_params
+        )
 
         output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
@@ -61,10 +62,8 @@ def figure_2(args):
             impl_params=args.impl_params,
         )
         filename = make_output_filename(
-            ["gatys_et_al_2017", "fig_2", label],
-            impl_params=args.impl_params
+            ["gatys_et_al_2017", "fig_2", label], impl_params=args.impl_params
         )
-
         output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
 
@@ -154,8 +153,7 @@ def figure_3(args):
             impl_params=args.impl_params,
         )
         filename = make_output_filename(
-            ["gatys_et_al_2017", "fig_3", "c"],
-            impl_params=args.impl_params
+            ["gatys_et_al_2017", "fig_3", "c"], impl_params=args.impl_params
         )
         output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
@@ -179,8 +177,7 @@ def figure_3(args):
         output_image_yuv = torch.cat((output_luminance, output_chromaticity), dim=1)
         output_image = yuv_to_rgb(output_image_yuv)
         filename = make_output_filename(
-            ["gatys_et_al_2017", "fig_3", "d"],
-            impl_params=args.impl_params
+            ["gatys_et_al_2017", "fig_3", "d"], impl_params=args.impl_params
         )
         output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)
@@ -196,8 +193,7 @@ def figure_3(args):
             impl_params=args.impl_params,
         )
         filename = make_output_filename(
-            ["gatys_et_al_2017", "fig_3", "e"],
-            impl_params=args.impl_params
+            ["gatys_et_al_2017", "fig_3", "e"], impl_params=args.impl_params
         )
         output_file = path.join(args.image_results_dir, filename)
         save_result(output_image, output_file)

--- a/replication/li_wand_2016/main.py
+++ b/replication/li_wand_2016/main.py
@@ -41,8 +41,7 @@ def figure_6(args):
             hyper_parameters=hyper_parameters,
         )
         filename = make_output_filename(
-            ["li_wand_2016", "fig_6", position],
-            impl_params=args.impl_params
+            ["li_wand_2016", "fig_6", position], impl_params=args.impl_params
         )
         output_file = path.join(args.image_results_dir, filename)
         print(f"Saving result to {output_file}")

--- a/replication/li_wand_2016/main.py
+++ b/replication/li_wand_2016/main.py
@@ -5,7 +5,7 @@ from os import path
 import pystiche_papers.li_wand_2016 as paper
 from pystiche.image import write_image
 from pystiche.misc import get_device
-from pystiche_papers.utils import abort_if_cuda_memory_exausts
+from pystiche_papers.utils import abort_if_cuda_memory_exausts, make_output_filename
 
 
 @abort_if_cuda_memory_exausts
@@ -40,8 +40,11 @@ def figure_6(args):
             impl_params=args.impl_params,
             hyper_parameters=hyper_parameters,
         )
-
-        output_file = path.join(args.image_results_dir, f"fig_6__{position}.jpg")
+        filename = make_output_filename(
+            ["li_wand_2016", "fig_6", position],
+            impl_params=args.impl_params
+        )
+        output_file = path.join(args.image_results_dir, filename)
         print(f"Saving result to {output_file}")
         write_image(output_image, output_file)
         print("#" * int(os.environ.get("COLUMNS", "80")))

--- a/replication/li_wand_2016/main.py
+++ b/replication/li_wand_2016/main.py
@@ -41,7 +41,10 @@ def figure_6(args):
             hyper_parameters=hyper_parameters,
         )
         filename = make_output_filename(
-            "li_wand_2016", "fig_6", position, impl_params=args.impl_params
+            "li_wand_2016",
+            "fig_6",
+            position,
+            impl_params=args.impl_params,
         )
         output_file = path.join(args.image_results_dir, filename)
         print(f"Saving result to {output_file}")

--- a/replication/li_wand_2016/main.py
+++ b/replication/li_wand_2016/main.py
@@ -41,7 +41,7 @@ def figure_6(args):
             hyper_parameters=hyper_parameters,
         )
         filename = make_output_filename(
-            ["li_wand_2016", "fig_6", position], impl_params=args.impl_params
+            "li_wand_2016", "fig_6", position, impl_params=args.impl_params
         )
         output_file = path.join(args.image_results_dir, filename)
         print(f"Saving result to {output_file}")

--- a/replication/ulyanov_et_al_2016/main.py
+++ b/replication/ulyanov_et_al_2016/main.py
@@ -59,13 +59,12 @@ def training(args):
                 impl_params=args.impl_params,
                 instance_norm=args.instance_norm,
             )
-
-            output_name = f"{style}_{content}"
-            if args.impl_params:
-                output_name += "__impl_params"
-            if args.instance_norm:
-                output_name += "__instance_norm"
-            output_file = path.join(args.image_results_dir, f"{output_name}.png")
+            filename = utils.make_output_filename(
+                ["ulyanov_et_al_2016", style, content],
+                impl_params=args.impl_params,
+                instance_norm=args.instance_norm,
+            )
+            output_file = path.join(args.image_results_dir, filename)
             image.write_image(output_image, output_file)
 
 

--- a/replication/ulyanov_et_al_2016/main.py
+++ b/replication/ulyanov_et_al_2016/main.py
@@ -60,7 +60,9 @@ def training(args):
                 instance_norm=args.instance_norm,
             )
             filename = utils.make_output_filename(
-                ["ulyanov_et_al_2016", style, content],
+                "ulyanov_et_al_2016",
+                style,
+                content,
                 impl_params=args.impl_params,
                 instance_norm=args.instance_norm,
             )

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -280,3 +280,24 @@ def test_select_url_from_csv_converter(urls_csv):
         file, config, converters={fieldname: utils.str_to_bool}
     )
     assert actual_url == expected_url
+
+
+def test_make_output_filename():
+    name_parts = ["A", "B", "C"]
+    actual_filename = utils.make_output_filename(name_parts)
+    expected_filename = "A__B__C__impl_params.jpg"
+    assert actual_filename == expected_filename
+
+
+def test_make_output_filename_extension():
+    name_parts = ["A", "B", "C"]
+    actual_filename = utils.make_output_filename(name_parts, extension=".png")
+    expected_filename = "A__B__C__impl_params.png"
+    assert actual_filename == expected_filename
+
+
+def test_make_output_filename_no_impl_params():
+    name_parts = ["A", "B", "C"]
+    actual_filename = utils.make_output_filename(name_parts, impl_params=False)
+    expected_filename = "A__B__C.jpg"
+    assert actual_filename == expected_filename

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -284,20 +284,20 @@ def test_select_url_from_csv_converter(urls_csv):
 
 def test_make_output_filename():
     name_parts = ["A", "B", "C"]
-    actual_filename = utils.make_output_filename(name_parts)
+    actual_filename = utils.make_output_filename(*name_parts)
     expected_filename = "A__B__C__impl_params.jpg"
     assert actual_filename == expected_filename
 
 
 def test_make_output_filename_extension():
     name_parts = ["A", "B", "C"]
-    actual_filename = utils.make_output_filename(name_parts, extension=".png")
+    actual_filename = utils.make_output_filename(*name_parts, extension=".png")
     expected_filename = "A__B__C__impl_params.png"
     assert actual_filename == expected_filename
 
 
 def test_make_output_filename_no_impl_params():
     name_parts = ["A", "B", "C"]
-    actual_filename = utils.make_output_filename(name_parts, impl_params=False)
+    actual_filename = utils.make_output_filename(*name_parts, impl_params=False)
     expected_filename = "A__B__C.jpg"
     assert actual_filename == expected_filename

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -293,17 +293,3 @@ def test_select_url_from_csv_converter(urls_csv):
 )
 def test_make_output_filename(args, kwargs, expected):
     assert utils.make_output_filename(*args, **kwargs) == expected
-
-
-def test_make_output_filename_extension():
-    name_parts = ["A", "B", "C"]
-    actual_filename = utils.make_output_filename(*name_parts, extension=".png")
-    expected_filename = "A__B__C__impl_params.png"
-    assert actual_filename == expected_filename
-
-
-def test_make_output_filename_no_impl_params():
-    name_parts = ["A", "B", "C"]
-    actual_filename = utils.make_output_filename(*name_parts, impl_params=False)
-    expected_filename = "A__B__C.jpg"
-    assert actual_filename == expected_filename

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -282,11 +282,17 @@ def test_select_url_from_csv_converter(urls_csv):
     assert actual_url == expected_url
 
 
-def test_make_output_filename():
-    name_parts = ["A", "B", "C"]
-    actual_filename = utils.make_output_filename(*name_parts)
-    expected_filename = "A__B__C__impl_params.jpg"
-    assert actual_filename == expected_filename
+@pytest.mark.parametrize(
+    ("args", "kwargs", "expected"),
+    [
+        (("A", "B", "C"), dict(), "A__B__C.jpg"),
+        (("A", "B", "C"), dict(extension=".png"), "A__B__C.png"),
+        (("A", "B", "C"), dict(impl_params=True), "A__B__C__impl_params.jpg"),
+        (("A", "B", "C"), dict(impl_params=False), "A__B__C.jpg"),
+    ],
+)
+def test_make_output_filename(args, kwargs, expected):
+    assert utils.make_output_filename(*args, **kwargs) == expected
 
 
 def test_make_output_filename_extension():


### PR DESCRIPTION
As mentioned in [#275](https://github.com/pystiche/papers/issues/275) the output file names are not yet ideal. This PR addresses this problem by making the file names more consistent. They now essentially consist of three components. 

1. The name of the replication.
2. Additional parameters that are important for the name (figure labels, hyperparameters, ...).
3. An optional flag indicating whether the `impl_params` are used.

Example of current filename:
"_gatys_ecker_betghe_2016__fig_2__B__impl_params.jpg_"