### PR TITLE
Fix image sources

### DIFF
--- a/pystiche_papers/gatys_et_al_2017/_data.py
+++ b/pystiche_papers/gatys_et_al_2017/_data.py
@@ -14,9 +14,8 @@ def license(original: Optional[str] = None) -> str:
     if original:
         license_text = (
             f"{license_text} The original was probably downloaded from {original}. "
-            f"Proceed at your own risk."
         )
-    return license_text
+    return f"{license_text} Proceed at your own risk."
 
 
 def images() -> data.DownloadableImageCollection:

--- a/pystiche_papers/gatys_et_al_2017/_data.py
+++ b/pystiche_papers/gatys_et_al_2017/_data.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from pystiche import data
-from pystiche_papers.utils import license
 
 __all__ = ["images"]
 
@@ -12,7 +11,12 @@ def license_info(original: Optional[str] = None) -> str:
         "non-commercial use only "
         "(https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/README.md?plain=1#L48)."
     )
-    return license(license_text, original=original)
+    if original:
+        license_text = (
+            f"{license_text} The original was probably downloaded from {original}. "
+            f"Proceed at your own risk."
+        )
+    return license_text
 
 
 def images() -> data.DownloadableImageCollection:
@@ -47,7 +51,7 @@ def images() -> data.DownloadableImageCollection:
             "watertown": data.DownloadableImage(
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1.jpg?raw=true",
                 file="watertown.jpg",
-                license=license("https://de.aliexpress.com/item/1705231003.html"),
+                license=license_info("https://de.aliexpress.com/item/1705231003.html"),
                 md5="4cc98a503da5ce6eab0649b09fd3cf77",
                 guides=data.DownloadableImageCollection(
                     {

--- a/pystiche_papers/gatys_et_al_2017/_data.py
+++ b/pystiche_papers/gatys_et_al_2017/_data.py
@@ -6,16 +6,14 @@ __all__ = ["images"]
 
 
 def license(original: Optional[str] = None) -> str:
-    license_text = (
+    license = (
         "The image is part of a repository that is published for academic and "
         "non-commercial use only "
         "(https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/README.md?plain=1#L48)."
     )
     if original:
-        license_text = (
-            f"{license_text} The original was probably downloaded from {original}. "
-        )
-    return f"{license_text} Proceed at your own risk."
+        license = f"{license} The original was probably downloaded from {original}. "
+    return f"{license} Proceed at your own risk."
 
 
 def images() -> data.DownloadableImageCollection:
@@ -25,7 +23,7 @@ def images() -> data.DownloadableImageCollection:
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_content.jpg?raw=true",
                 file="house_concept_tillamook.jpg",
                 license=license(
-                    "https://associateddesigns.com/sites/default/files/plan_images/main/craftsman_house_plan_tillamook_30-519-picart.jpg",
+                    "https://associateddesigns.com/sites/default/files/plan_images/main/craftsman_house_plan_tillamook_30-519-picart.jpg"
                 ),
                 md5="5629bf7b24a7c98db2580ec2a8d784e9",
                 guides=data.DownloadableImageCollection(
@@ -75,7 +73,7 @@ def images() -> data.DownloadableImageCollection:
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style2.jpg?raw=true",
                 file="wheat_field.jpg",
                 license=license(
-                    "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ce/Wheat-Field-with-Cypresses-%281889%29-Vincent-van-Gogh-Met.jpg/1920px-Wheat-Field-with-Cypresses-%281889%29-Vincent-van-Gogh-Met.jpg",
+                    "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ce/Wheat-Field-with-Cypresses-%281889%29-Vincent-van-Gogh-Met.jpg/1920px-Wheat-Field-with-Cypresses-%281889%29-Vincent-van-Gogh-Met.jpg"
                 ),
                 md5="4af9e64534c055bf7db5ee3ab7daf608",
                 guides=data.DownloadableImageCollection(
@@ -101,7 +99,7 @@ def images() -> data.DownloadableImageCollection:
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig3_content.jpg?raw=true",
                 file="schultenhof.jpg",
                 license=license(
-                    "https://upload.wikimedia.org/wikipedia/commons/8/82/Schultenhof_Mettingen_Bauerngarten_8.jpg",
+                    "https://upload.wikimedia.org/wikipedia/commons/8/82/Schultenhof_Mettingen_Bauerngarten_8.jpg"
                 ),
                 md5="23f75f148b7b94d932e599bf0c5e4c8e",
             ),
@@ -109,7 +107,7 @@ def images() -> data.DownloadableImageCollection:
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig3_style1.jpg?raw=true",
                 file="starry_night_over_the_rhone.jpg",
                 license=license(
-                    "https://upload.wikimedia.org/wikipedia/commons/9/94/Starry_Night_Over_the_Rhone.jpg",
+                    "https://upload.wikimedia.org/wikipedia/commons/9/94/Starry_Night_Over_the_Rhone.jpg"
                 ),
                 md5="e67c25e4aa6070cc4e5ab7f3ce91c218",
             ),

--- a/pystiche_papers/gatys_et_al_2017/_data.py
+++ b/pystiche_papers/gatys_et_al_2017/_data.py
@@ -5,7 +5,7 @@ from pystiche import data
 __all__ = ["images"]
 
 
-def license_info(original: Optional[str] = None) -> str:
+def license(original: Optional[str] = None) -> str:
     license_text = (
         "The image is part of a repository that is published for academic and "
         "non-commercial use only "
@@ -25,7 +25,7 @@ def images() -> data.DownloadableImageCollection:
             "house": data.DownloadableImage(
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_content.jpg?raw=true",
                 file="house_concept_tillamook.jpg",
-                license=license_info(
+                license=license(
                     "https://associateddesigns.com/sites/default/files/plan_images/main/craftsman_house_plan_tillamook_30-519-picart.jpg",
                 ),
                 md5="5629bf7b24a7c98db2580ec2a8d784e9",
@@ -35,14 +35,14 @@ def images() -> data.DownloadableImageCollection:
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1_nosky.jpg?raw=true",
                             file="building.jpg",
                             author="Gatys et al.",
-                            license=license_info(),
+                            license=license(),
                             md5="1fa945871244cf1cefc5e08f8da83fdf",
                         ),
                         "sky": data.DownloadableImage(
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1_sky.jpg?raw=true",
                             file="sky.jpg",
                             author="Gatys et al.",
-                            license=license_info(),
+                            license=license(),
                             md5="3c21f0d573cc73a6b58b9d559117805b",
                         ),
                     }
@@ -51,7 +51,7 @@ def images() -> data.DownloadableImageCollection:
             "watertown": data.DownloadableImage(
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1.jpg?raw=true",
                 file="watertown.jpg",
-                license=license_info("https://de.aliexpress.com/item/1705231003.html"),
+                license=license("https://de.aliexpress.com/item/1705231003.html"),
                 md5="4cc98a503da5ce6eab0649b09fd3cf77",
                 guides=data.DownloadableImageCollection(
                     {
@@ -59,14 +59,14 @@ def images() -> data.DownloadableImageCollection:
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1_nosky.jpg?raw=true",
                             file="building.jpg",
                             author="Gatys et al.",
-                            license=license_info(),
+                            license=license(),
                             md5="1fa945871244cf1cefc5e08f8da83fdf",
                         ),
                         "sky": data.DownloadableImage(
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1_sky.jpg?raw=true",
                             file="sky.jpg",
                             author="Gatys et al.",
-                            license=license_info(),
+                            license=license(),
                             md5="3c21f0d573cc73a6b58b9d559117805b",
                         ),
                     }
@@ -75,7 +75,7 @@ def images() -> data.DownloadableImageCollection:
             "wheat_field": data.DownloadableImage(
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style2.jpg?raw=true",
                 file="wheat_field.jpg",
-                license=license_info(
+                license=license(
                     "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ce/Wheat-Field-with-Cypresses-%281889%29-Vincent-van-Gogh-Met.jpg/1920px-Wheat-Field-with-Cypresses-%281889%29-Vincent-van-Gogh-Met.jpg",
                 ),
                 md5="4af9e64534c055bf7db5ee3ab7daf608",
@@ -85,14 +85,14 @@ def images() -> data.DownloadableImageCollection:
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style2_nosky.jpg?raw=true",
                             file="foreground.jpg",
                             author="Gatys et al.",
-                            license=license_info(),
+                            license=license(),
                             md5="67c6e653f4aa629140cb2fc53a3406d9",
                         ),
                         "sky": data.DownloadableImage(
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style2_nosky.jpg?raw=true",
                             file="sky.jpg",
                             author="Gatys et al.",
-                            license=license_info(),
+                            license=license(),
                             md5="67c6e653f4aa629140cb2fc53a3406d9",
                         ),
                     }
@@ -101,7 +101,7 @@ def images() -> data.DownloadableImageCollection:
             "schultenhof": data.DownloadableImage(
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig3_content.jpg?raw=true",
                 file="schultenhof.jpg",
-                license=license_info(
+                license=license(
                     "https://upload.wikimedia.org/wikipedia/commons/8/82/Schultenhof_Mettingen_Bauerngarten_8.jpg",
                 ),
                 md5="23f75f148b7b94d932e599bf0c5e4c8e",
@@ -109,7 +109,7 @@ def images() -> data.DownloadableImageCollection:
             "starry_night": data.DownloadableImage(
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig3_style1.jpg?raw=true",
                 file="starry_night_over_the_rhone.jpg",
-                license=license_info(
+                license=license(
                     "https://upload.wikimedia.org/wikipedia/commons/9/94/Starry_Night_Over_the_Rhone.jpg",
                 ),
                 md5="e67c25e4aa6070cc4e5ab7f3ce91c218",

--- a/pystiche_papers/gatys_et_al_2017/_data.py
+++ b/pystiche_papers/gatys_et_al_2017/_data.py
@@ -1,33 +1,19 @@
-from typing import Optional
-
 from pystiche import data
+from pystiche_papers.utils import license
 
 __all__ = ["images"]
 
 
-def license(original: Optional[str] = None) -> str:
-    license = (
-        "The image is part of a repository that is published for academic and "
-        "non-commercial use only "
-        "(https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/README.md?plain=1#L48)."
-    )
-    if original:
-        license = (
-            f"{license} The original was probably downloaded from {original}. "
-            f"Proceed at your own risk."
-        )
-
-    return license
-
-
 def images() -> data.DownloadableImageCollection:
+    license_source = "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/README.md?plain=1#L48"
     return data.DownloadableImageCollection(
         {
             "house": data.DownloadableImage(
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_content.jpg?raw=true",
                 file="house_concept_tillamook.jpg",
                 license=license(
-                    "https://associateddesigns.com/sites/default/files/plan_images/main/craftsman_house_plan_tillamook_30-519-picart.jpg"
+                    license_source,
+                    "https://associateddesigns.com/sites/default/files/plan_images/main/craftsman_house_plan_tillamook_30-519-picart.jpg",
                 ),
                 md5="5629bf7b24a7c98db2580ec2a8d784e9",
                 guides=data.DownloadableImageCollection(
@@ -36,14 +22,14 @@ def images() -> data.DownloadableImageCollection:
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1_nosky.jpg?raw=true",
                             file="building.jpg",
                             author="Gatys et al.",
-                            license=license(),
+                            license=license(license_source),
                             md5="1fa945871244cf1cefc5e08f8da83fdf",
                         ),
                         "sky": data.DownloadableImage(
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1_sky.jpg?raw=true",
                             file="sky.jpg",
                             author="Gatys et al.",
-                            license=license(),
+                            license=license(license_source),
                             md5="3c21f0d573cc73a6b58b9d559117805b",
                         ),
                     }
@@ -52,7 +38,9 @@ def images() -> data.DownloadableImageCollection:
             "watertown": data.DownloadableImage(
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1.jpg?raw=true",
                 file="watertown.jpg",
-                license=license("https://de.aliexpress.com/item/1705231003.html"),
+                license=license(
+                    license_source, "https://de.aliexpress.com/item/1705231003.html"
+                ),
                 md5="4cc98a503da5ce6eab0649b09fd3cf77",
                 guides=data.DownloadableImageCollection(
                     {
@@ -60,14 +48,14 @@ def images() -> data.DownloadableImageCollection:
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1_nosky.jpg?raw=true",
                             file="building.jpg",
                             author="Gatys et al.",
-                            license=license(),
+                            license=license(license_source),
                             md5="1fa945871244cf1cefc5e08f8da83fdf",
                         ),
                         "sky": data.DownloadableImage(
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1_sky.jpg?raw=true",
                             file="sky.jpg",
                             author="Gatys et al.",
-                            license=license(),
+                            license=license(license_source),
                             md5="3c21f0d573cc73a6b58b9d559117805b",
                         ),
                     }
@@ -77,7 +65,8 @@ def images() -> data.DownloadableImageCollection:
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style2.jpg?raw=true",
                 file="wheat_field.jpg",
                 license=license(
-                    "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ce/Wheat-Field-with-Cypresses-%281889%29-Vincent-van-Gogh-Met.jpg/1920px-Wheat-Field-with-Cypresses-%281889%29-Vincent-van-Gogh-Met.jpg"
+                    license_source,
+                    "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ce/Wheat-Field-with-Cypresses-%281889%29-Vincent-van-Gogh-Met.jpg/1920px-Wheat-Field-with-Cypresses-%281889%29-Vincent-van-Gogh-Met.jpg",
                 ),
                 md5="4af9e64534c055bf7db5ee3ab7daf608",
                 guides=data.DownloadableImageCollection(
@@ -86,14 +75,14 @@ def images() -> data.DownloadableImageCollection:
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style2_nosky.jpg?raw=true",
                             file="foreground.jpg",
                             author="Gatys et al.",
-                            license=license(),
+                            license=license(license_source),
                             md5="67c6e653f4aa629140cb2fc53a3406d9",
                         ),
                         "sky": data.DownloadableImage(
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style2_nosky.jpg?raw=true",
                             file="sky.jpg",
                             author="Gatys et al.",
-                            license=license(),
+                            license=license(license_source),
                             md5="67c6e653f4aa629140cb2fc53a3406d9",
                         ),
                     }
@@ -103,7 +92,8 @@ def images() -> data.DownloadableImageCollection:
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig3_content.jpg?raw=true",
                 file="schultenhof.jpg",
                 license=license(
-                    "https://upload.wikimedia.org/wikipedia/commons/8/82/Schultenhof_Mettingen_Bauerngarten_8.jpg"
+                    license_source,
+                    "https://upload.wikimedia.org/wikipedia/commons/8/82/Schultenhof_Mettingen_Bauerngarten_8.jpg",
                 ),
                 md5="23f75f148b7b94d932e599bf0c5e4c8e",
             ),
@@ -111,7 +101,8 @@ def images() -> data.DownloadableImageCollection:
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig3_style1.jpg?raw=true",
                 file="starry_night_over_the_rhone.jpg",
                 license=license(
-                    "https://upload.wikimedia.org/wikipedia/commons/9/94/Starry_Night_Over_the_Rhone.jpg"
+                    license_source,
+                    "https://upload.wikimedia.org/wikipedia/commons/9/94/Starry_Night_Over_the_Rhone.jpg",
                 ),
                 md5="e67c25e4aa6070cc4e5ab7f3ce91c218",
             ),

--- a/pystiche_papers/gatys_et_al_2017/_data.py
+++ b/pystiche_papers/gatys_et_al_2017/_data.py
@@ -1,18 +1,27 @@
+from typing import Optional
+
 from pystiche import data
 from pystiche_papers.utils import license
 
 __all__ = ["images"]
 
 
+def license_info(original: Optional[str] = None)-> str:
+    license_text = (
+        "The image is part of a repository that is published for academic and "
+        "non-commercial use only "
+        "(https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/README.md?plain=1#L48)."
+    )
+    return license(license_text, original=original)
+
+
 def images() -> data.DownloadableImageCollection:
-    license_source = "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/README.md?plain=1#L48"
     return data.DownloadableImageCollection(
         {
             "house": data.DownloadableImage(
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_content.jpg?raw=true",
                 file="house_concept_tillamook.jpg",
-                license=license(
-                    license_source,
+                license=license_info(
                     "https://associateddesigns.com/sites/default/files/plan_images/main/craftsman_house_plan_tillamook_30-519-picart.jpg",
                 ),
                 md5="5629bf7b24a7c98db2580ec2a8d784e9",
@@ -22,14 +31,14 @@ def images() -> data.DownloadableImageCollection:
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1_nosky.jpg?raw=true",
                             file="building.jpg",
                             author="Gatys et al.",
-                            license=license(license_source),
+                            license=license_info(),
                             md5="1fa945871244cf1cefc5e08f8da83fdf",
                         ),
                         "sky": data.DownloadableImage(
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1_sky.jpg?raw=true",
                             file="sky.jpg",
                             author="Gatys et al.",
-                            license=license(license_source),
+                            license=license(),
                             md5="3c21f0d573cc73a6b58b9d559117805b",
                         ),
                     }
@@ -39,7 +48,7 @@ def images() -> data.DownloadableImageCollection:
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1.jpg?raw=true",
                 file="watertown.jpg",
                 license=license(
-                    license_source, "https://de.aliexpress.com/item/1705231003.html"
+                    "https://de.aliexpress.com/item/1705231003.html"
                 ),
                 md5="4cc98a503da5ce6eab0649b09fd3cf77",
                 guides=data.DownloadableImageCollection(
@@ -48,14 +57,14 @@ def images() -> data.DownloadableImageCollection:
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1_nosky.jpg?raw=true",
                             file="building.jpg",
                             author="Gatys et al.",
-                            license=license(license_source),
+                            license=license(),
                             md5="1fa945871244cf1cefc5e08f8da83fdf",
                         ),
                         "sky": data.DownloadableImage(
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1_sky.jpg?raw=true",
                             file="sky.jpg",
                             author="Gatys et al.",
-                            license=license(license_source),
+                            license=license(),
                             md5="3c21f0d573cc73a6b58b9d559117805b",
                         ),
                     }
@@ -65,7 +74,6 @@ def images() -> data.DownloadableImageCollection:
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style2.jpg?raw=true",
                 file="wheat_field.jpg",
                 license=license(
-                    license_source,
                     "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ce/Wheat-Field-with-Cypresses-%281889%29-Vincent-van-Gogh-Met.jpg/1920px-Wheat-Field-with-Cypresses-%281889%29-Vincent-van-Gogh-Met.jpg",
                 ),
                 md5="4af9e64534c055bf7db5ee3ab7daf608",
@@ -75,14 +83,14 @@ def images() -> data.DownloadableImageCollection:
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style2_nosky.jpg?raw=true",
                             file="foreground.jpg",
                             author="Gatys et al.",
-                            license=license(license_source),
+                            license=license(),
                             md5="67c6e653f4aa629140cb2fc53a3406d9",
                         ),
                         "sky": data.DownloadableImage(
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style2_nosky.jpg?raw=true",
                             file="sky.jpg",
                             author="Gatys et al.",
-                            license=license(license_source),
+                            license=license(),
                             md5="67c6e653f4aa629140cb2fc53a3406d9",
                         ),
                     }
@@ -92,7 +100,6 @@ def images() -> data.DownloadableImageCollection:
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig3_content.jpg?raw=true",
                 file="schultenhof.jpg",
                 license=license(
-                    license_source,
                     "https://upload.wikimedia.org/wikipedia/commons/8/82/Schultenhof_Mettingen_Bauerngarten_8.jpg",
                 ),
                 md5="23f75f148b7b94d932e599bf0c5e4c8e",
@@ -101,7 +108,6 @@ def images() -> data.DownloadableImageCollection:
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig3_style1.jpg?raw=true",
                 file="starry_night_over_the_rhone.jpg",
                 license=license(
-                    license_source,
                     "https://upload.wikimedia.org/wikipedia/commons/9/94/Starry_Night_Over_the_Rhone.jpg",
                 ),
                 md5="e67c25e4aa6070cc4e5ab7f3ce91c218",

--- a/pystiche_papers/gatys_et_al_2017/_data.py
+++ b/pystiche_papers/gatys_et_al_2017/_data.py
@@ -6,7 +6,7 @@ from pystiche_papers.utils import license
 __all__ = ["images"]
 
 
-def license_info(original: Optional[str] = None)-> str:
+def license_info(original: Optional[str] = None) -> str:
     license_text = (
         "The image is part of a repository that is published for academic and "
         "non-commercial use only "
@@ -38,7 +38,7 @@ def images() -> data.DownloadableImageCollection:
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1_sky.jpg?raw=true",
                             file="sky.jpg",
                             author="Gatys et al.",
-                            license=license(),
+                            license=license_info(),
                             md5="3c21f0d573cc73a6b58b9d559117805b",
                         ),
                     }
@@ -47,9 +47,7 @@ def images() -> data.DownloadableImageCollection:
             "watertown": data.DownloadableImage(
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1.jpg?raw=true",
                 file="watertown.jpg",
-                license=license(
-                    "https://de.aliexpress.com/item/1705231003.html"
-                ),
+                license=license("https://de.aliexpress.com/item/1705231003.html"),
                 md5="4cc98a503da5ce6eab0649b09fd3cf77",
                 guides=data.DownloadableImageCollection(
                     {
@@ -57,14 +55,14 @@ def images() -> data.DownloadableImageCollection:
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1_nosky.jpg?raw=true",
                             file="building.jpg",
                             author="Gatys et al.",
-                            license=license(),
+                            license=license_info(),
                             md5="1fa945871244cf1cefc5e08f8da83fdf",
                         ),
                         "sky": data.DownloadableImage(
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style1_sky.jpg?raw=true",
                             file="sky.jpg",
                             author="Gatys et al.",
-                            license=license(),
+                            license=license_info(),
                             md5="3c21f0d573cc73a6b58b9d559117805b",
                         ),
                     }
@@ -73,7 +71,7 @@ def images() -> data.DownloadableImageCollection:
             "wheat_field": data.DownloadableImage(
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style2.jpg?raw=true",
                 file="wheat_field.jpg",
-                license=license(
+                license=license_info(
                     "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ce/Wheat-Field-with-Cypresses-%281889%29-Vincent-van-Gogh-Met.jpg/1920px-Wheat-Field-with-Cypresses-%281889%29-Vincent-van-Gogh-Met.jpg",
                 ),
                 md5="4af9e64534c055bf7db5ee3ab7daf608",
@@ -83,14 +81,14 @@ def images() -> data.DownloadableImageCollection:
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style2_nosky.jpg?raw=true",
                             file="foreground.jpg",
                             author="Gatys et al.",
-                            license=license(),
+                            license=license_info(),
                             md5="67c6e653f4aa629140cb2fc53a3406d9",
                         ),
                         "sky": data.DownloadableImage(
                             "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig2_style2_nosky.jpg?raw=true",
                             file="sky.jpg",
                             author="Gatys et al.",
-                            license=license(),
+                            license=license_info(),
                             md5="67c6e653f4aa629140cb2fc53a3406d9",
                         ),
                     }
@@ -99,7 +97,7 @@ def images() -> data.DownloadableImageCollection:
             "schultenhof": data.DownloadableImage(
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig3_content.jpg?raw=true",
                 file="schultenhof.jpg",
-                license=license(
+                license=license_info(
                     "https://upload.wikimedia.org/wikipedia/commons/8/82/Schultenhof_Mettingen_Bauerngarten_8.jpg",
                 ),
                 md5="23f75f148b7b94d932e599bf0c5e4c8e",
@@ -107,7 +105,7 @@ def images() -> data.DownloadableImageCollection:
             "starry_night": data.DownloadableImage(
                 "https://github.com/leongatys/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/Images/ControlPaper/fig3_style1.jpg?raw=true",
                 file="starry_night_over_the_rhone.jpg",
-                license=license(
+                license=license_info(
                     "https://upload.wikimedia.org/wikipedia/commons/9/94/Starry_Night_Over_the_Rhone.jpg",
                 ),
                 md5="e67c25e4aa6070cc4e5ab7f3ce91c218",

--- a/pystiche_papers/johnson_alahi_li_2016/_data.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_data.py
@@ -33,6 +33,7 @@ LICENSE = (
     "The image is part of a repository that is published for personal and "
     "research use only "
     "(https://github.com/jcjohnson/fast-neural-style/blob/master/README.md#license)."
+    "Proceed at your own risk."
 )
 
 

--- a/pystiche_papers/johnson_alahi_li_2016/_data.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_data.py
@@ -14,7 +14,7 @@ from pystiche.data import (
     ImageFolderDataset,
 )
 from pystiche.image import extract_image_size
-from pystiche_papers.utils import HyperParameters
+from pystiche_papers.utils import HyperParameters, license
 
 from ..data.utils import FiniteCycleBatchSampler
 from ..utils.transforms import OptionalGrayscaleToFakegrayscale
@@ -30,7 +30,16 @@ __all__ = [
 ]
 
 
-class TopLeftCropToMultiple(nn.Module):
+def license_info(original: Optional[str] = None) -> str:
+    license_text = (
+        "The image is part of a repository that is published for personal and "
+        "research use only "
+        "(https://github.com/jcjohnson/fast-neural-style/blob/master/README.md#license)."
+    )
+    return license(license_text, original=original)
+
+
+class TopLeftCropToMultiple(transforms.Transform):
     def __init__(self, multiple: int = 16):
         super().__init__()
         self.multiple = multiple
@@ -114,10 +123,13 @@ def images() -> DownloadableImageCollection:
     content_root = urljoin(root, "content/")
     content_images = {
         "chicago": DownloadableImage(
-            urljoin(content_root, "chicago.jpg"), md5="16ea186230a8a5131b224ddde01d0dd5"
+            urljoin(content_root, "chicago.jpg"),
+            license=license_info(),
+            md5="16ea186230a8a5131b224ddde01d0dd5"
         ),
         "hoovertowernight": DownloadableImage(
             urljoin(content_root, "hoovertowernight.jpg"),
+            license=license_info(),
             md5="97f7bab04e1f4c852fd2499356163b15",
         ),
     }
@@ -125,34 +137,48 @@ def images() -> DownloadableImageCollection:
     style_root = urljoin(root, "styles/")
     style_images = {
         "candy": DownloadableImage(
-            urljoin(style_root, "candy.jpg"), md5="00a0e3aa9775546f98abf6417e3cb478"
+            urljoin(style_root, "candy.jpg"),
+            license=license_info(),
+            md5="00a0e3aa9775546f98abf6417e3cb478"
         ),
         "composition_vii": DownloadableImage(
             urljoin(style_root, "composition_vii.jpg"),
+            license=license_info(),
             md5="8d4f97cb0e8b1b07dee923599ee86cbd",
         ),
         "feathers": DownloadableImage(
-            urljoin(style_root, "feathers.jpg"), md5="461c8a1704b59af1cf686883b16feec6"
+            urljoin(style_root, "feathers.jpg"),
+            license=license_info(),
+            md5="461c8a1704b59af1cf686883b16feec6"
         ),
         "la_muse": DownloadableImage(
-            urljoin(style_root, "la_muse.jpg"), md5="77262ef6985cc427f84d78784ab5c1d8"
+            urljoin(style_root, "la_muse.jpg"),
+            license=license_info(),
+            md5="77262ef6985cc427f84d78784ab5c1d8"
         ),
         "mosaic": DownloadableImage(
-            urljoin(style_root, "mosaic.jpg"), md5="67b11e9cb1a69df08d70d9c2c7778fba"
+            urljoin(style_root, "mosaic.jpg"),
+            license=license_info(),
+            md5="67b11e9cb1a69df08d70d9c2c7778fba"
         ),
         "starry_night": DownloadableImage(
             urljoin(style_root, "starry_night.jpg"),
+            license=license_info(),
             md5="ff217acb6db32785b8651a0e316aeab3",
         ),
         "the_scream": DownloadableImage(
             urljoin(style_root, "the_scream.jpg"),
+            license=license_info(),
             md5="619b4f42c84d2b62d3518fb20fa619c2",
         ),
         "udnie": DownloadableImage(
-            urljoin(style_root, "udnie.jpg"), md5="6f3fa51706b21580a4b77f232d3b8ba9"
+            urljoin(style_root, "udnie.jpg"),
+            license=license_info(),
+            md5="6f3fa51706b21580a4b77f232d3b8ba9"
         ),
         "the_wave": DownloadableImage(
             urljoin(style_root, "wave.jpg"),
+            license=license_info(),
             md5="b06acee16641a2a04fb87bade8cee529",
             file="the_wave.jpg",
         ),

--- a/pystiche_papers/johnson_alahi_li_2016/_data.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_data.py
@@ -39,7 +39,7 @@ def license_info(original: Optional[str] = None) -> str:
     return license(license_text, original=original)
 
 
-class TopLeftCropToMultiple(transforms.Transform):
+class TopLeftCropToMultiple(nn.Module):
     def __init__(self, multiple: int = 16):
         super().__init__()
         self.multiple = multiple

--- a/pystiche_papers/johnson_alahi_li_2016/_data.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_data.py
@@ -29,12 +29,11 @@ __all__ = [
     "image_loader",
 ]
 
-
 LICENSE = (
     "The image is part of a repository that is published for personal and "
     "research use only "
     "(https://github.com/jcjohnson/fast-neural-style/blob/master/README.md#license)."
-    )
+)
 
 
 class TopLeftCropToMultiple(nn.Module):
@@ -122,12 +121,12 @@ def images() -> DownloadableImageCollection:
     content_images = {
         "chicago": DownloadableImage(
             urljoin(content_root, "chicago.jpg"),
-            license=license_info(),
+            license=LICENSE,
             md5="16ea186230a8a5131b224ddde01d0dd5",
         ),
         "hoovertowernight": DownloadableImage(
             urljoin(content_root, "hoovertowernight.jpg"),
-            license=license_info(),
+            license=LICENSE,
             md5="97f7bab04e1f4c852fd2499356163b15",
         ),
     }
@@ -136,47 +135,47 @@ def images() -> DownloadableImageCollection:
     style_images = {
         "candy": DownloadableImage(
             urljoin(style_root, "candy.jpg"),
-            license=license_info(),
+            license=LICENSE,
             md5="00a0e3aa9775546f98abf6417e3cb478",
         ),
         "composition_vii": DownloadableImage(
             urljoin(style_root, "composition_vii.jpg"),
-            license=license_info(),
+            license=LICENSE,
             md5="8d4f97cb0e8b1b07dee923599ee86cbd",
         ),
         "feathers": DownloadableImage(
             urljoin(style_root, "feathers.jpg"),
-            license=license_info(),
+            license=LICENSE,
             md5="461c8a1704b59af1cf686883b16feec6",
         ),
         "la_muse": DownloadableImage(
             urljoin(style_root, "la_muse.jpg"),
-            license=license_info(),
+            license=LICENSE,
             md5="77262ef6985cc427f84d78784ab5c1d8",
         ),
         "mosaic": DownloadableImage(
             urljoin(style_root, "mosaic.jpg"),
-            license=license_info(),
+            license=LICENSE,
             md5="67b11e9cb1a69df08d70d9c2c7778fba",
         ),
         "starry_night": DownloadableImage(
             urljoin(style_root, "starry_night.jpg"),
-            license=license_info(),
+            license=LICENSE,
             md5="ff217acb6db32785b8651a0e316aeab3",
         ),
         "the_scream": DownloadableImage(
             urljoin(style_root, "the_scream.jpg"),
-            license=license_info(),
+            license=LICENSE,
             md5="619b4f42c84d2b62d3518fb20fa619c2",
         ),
         "udnie": DownloadableImage(
             urljoin(style_root, "udnie.jpg"),
-            license=license_info(),
+            license=LICENSE,
             md5="6f3fa51706b21580a4b77f232d3b8ba9",
         ),
         "the_wave": DownloadableImage(
             urljoin(style_root, "wave.jpg"),
-            license=license_info(),
+            license=LICENSE,
             md5="b06acee16641a2a04fb87bade8cee529",
             file="the_wave.jpg",
         ),

--- a/pystiche_papers/johnson_alahi_li_2016/_data.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_data.py
@@ -14,7 +14,7 @@ from pystiche.data import (
     ImageFolderDataset,
 )
 from pystiche.image import extract_image_size
-from pystiche_papers.utils import HyperParameters, license
+from pystiche_papers.utils import HyperParameters
 
 from ..data.utils import FiniteCycleBatchSampler
 from ..utils.transforms import OptionalGrayscaleToFakegrayscale
@@ -30,13 +30,13 @@ __all__ = [
 ]
 
 
-def license_info(original: Optional[str] = None) -> str:
+def license_info() -> str:
     license_text = (
         "The image is part of a repository that is published for personal and "
         "research use only "
         "(https://github.com/jcjohnson/fast-neural-style/blob/master/README.md#license)."
     )
-    return license(license_text, original=original)
+    return license_text
 
 
 class TopLeftCropToMultiple(nn.Module):

--- a/pystiche_papers/johnson_alahi_li_2016/_data.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_data.py
@@ -125,7 +125,7 @@ def images() -> DownloadableImageCollection:
         "chicago": DownloadableImage(
             urljoin(content_root, "chicago.jpg"),
             license=license_info(),
-            md5="16ea186230a8a5131b224ddde01d0dd5"
+            md5="16ea186230a8a5131b224ddde01d0dd5",
         ),
         "hoovertowernight": DownloadableImage(
             urljoin(content_root, "hoovertowernight.jpg"),
@@ -139,7 +139,7 @@ def images() -> DownloadableImageCollection:
         "candy": DownloadableImage(
             urljoin(style_root, "candy.jpg"),
             license=license_info(),
-            md5="00a0e3aa9775546f98abf6417e3cb478"
+            md5="00a0e3aa9775546f98abf6417e3cb478",
         ),
         "composition_vii": DownloadableImage(
             urljoin(style_root, "composition_vii.jpg"),
@@ -149,17 +149,17 @@ def images() -> DownloadableImageCollection:
         "feathers": DownloadableImage(
             urljoin(style_root, "feathers.jpg"),
             license=license_info(),
-            md5="461c8a1704b59af1cf686883b16feec6"
+            md5="461c8a1704b59af1cf686883b16feec6",
         ),
         "la_muse": DownloadableImage(
             urljoin(style_root, "la_muse.jpg"),
             license=license_info(),
-            md5="77262ef6985cc427f84d78784ab5c1d8"
+            md5="77262ef6985cc427f84d78784ab5c1d8",
         ),
         "mosaic": DownloadableImage(
             urljoin(style_root, "mosaic.jpg"),
             license=license_info(),
-            md5="67b11e9cb1a69df08d70d9c2c7778fba"
+            md5="67b11e9cb1a69df08d70d9c2c7778fba",
         ),
         "starry_night": DownloadableImage(
             urljoin(style_root, "starry_night.jpg"),
@@ -174,7 +174,7 @@ def images() -> DownloadableImageCollection:
         "udnie": DownloadableImage(
             urljoin(style_root, "udnie.jpg"),
             license=license_info(),
-            md5="6f3fa51706b21580a4b77f232d3b8ba9"
+            md5="6f3fa51706b21580a4b77f232d3b8ba9",
         ),
         "the_wave": DownloadableImage(
             urljoin(style_root, "wave.jpg"),

--- a/pystiche_papers/johnson_alahi_li_2016/_data.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_data.py
@@ -30,13 +30,11 @@ __all__ = [
 ]
 
 
-def license_info() -> str:
-    license_text = (
-        "The image is part of a repository that is published for personal and "
-        "research use only "
-        "(https://github.com/jcjohnson/fast-neural-style/blob/master/README.md#license)."
+LICENSE = (
+    "The image is part of a repository that is published for personal and "
+    "research use only "
+    "(https://github.com/jcjohnson/fast-neural-style/blob/master/README.md#license)."
     )
-    return license_text
 
 
 class TopLeftCropToMultiple(nn.Module):

--- a/pystiche_papers/li_wand_2016/_data.py
+++ b/pystiche_papers/li_wand_2016/_data.py
@@ -71,16 +71,16 @@ class ResizeToVertEdge(nn.Module):
 
 
 def license(original: Optional[str] = None) -> str:
-    license_text = (
+    license = (
         "The image is part of a repository that is published under the MIT License "
         "(MIT) "
         "(https://github.com/chuanli11/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/License#L1)."
     )
     if original:
         license_text = (
-            f"{license_text} The original was probably downloaded from {original}. "
+            f"{license} The original was probably downloaded from {original}. "
         )
-    return f"{license_text} Proceed at your own risk."
+    return f"{license} Proceed at your own risk."
 
 
 def image_note(url: str, mirror: bool = False) -> str:

--- a/pystiche_papers/li_wand_2016/_data.py
+++ b/pystiche_papers/li_wand_2016/_data.py
@@ -79,9 +79,8 @@ def license(original: Optional[str] = None) -> str:
     if original:
         license_text = (
             f"{license_text} The original was probably downloaded from {original}. "
-            f"Proceed at your own risk."
         )
-    return license_text
+    return f"{license_text} Proceed at your own risk."
 
 
 def image_note(url: str, mirror: bool = False) -> str:

--- a/pystiche_papers/li_wand_2016/_data.py
+++ b/pystiche_papers/li_wand_2016/_data.py
@@ -70,7 +70,7 @@ class ResizeToVertEdge(nn.Module):
         return f"size={self.size}"
 
 
-def license_info(original: Optional[str] = None) -> str:
+def license(original: Optional[str] = None) -> str:
     license_text = (
         "The image is part of a repository that is published under the MIT License "
         "(MIT) "
@@ -142,7 +142,7 @@ def images() -> data.DownloadableImageCollection:
             title="Blue Bottle",
             author="Christopher Michel (cmichel67)",
             date="02.09.2014",
-            license=license_info("https://www.flickr.com/photos/cmichel67/15112861945"),
+            license=license("https://www.flickr.com/photos/cmichel67/15112861945"),
             note=image_note("https://www.flickr.com/photos/cmichel67/15112861945"),
             md5="cb29d11ef6e1be7e074aa58700110e4f",
         ),

--- a/pystiche_papers/li_wand_2016/_data.py
+++ b/pystiche_papers/li_wand_2016/_data.py
@@ -70,17 +70,6 @@ class ResizeToVertEdge(nn.Module):
         return f"size={self.size}"
 
 
-def license(original: Optional[str] = None) -> str:
-    license = (
-        "The image is part of a repository that is published under the MIT License "
-        "(MIT) "
-        "(https://github.com/chuanli11/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/License#L1)."
-    )
-    if original:
-        license = f"{license} The original was probably downloaded from {original}. "
-    return f"{license} Proceed at your own risk."
-
-
 def image_note(url: str, mirror: bool = False) -> str:
     note = "The image is cropped"
     if mirror:
@@ -139,7 +128,12 @@ def images() -> data.DownloadableImageCollection:
             title="Blue Bottle",
             author="Christopher Michel (cmichel67)",
             date="02.09.2014",
-            license=license("https://www.flickr.com/photos/cmichel67/15112861945"),
+            license="The image is part of a repository that is published under the MIT "
+            "License (MIT) "
+            "(https://github.com/chuanli11/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/License#L1)."
+            "The original was probably downloaded from "
+            "https://www.flickr.com/photos/cmichel67/15112861945. "
+            "Proceed at your own risk.",
             note=image_note("https://www.flickr.com/photos/cmichel67/15112861945"),
             md5="cb29d11ef6e1be7e074aa58700110e4f",
         ),

--- a/pystiche_papers/li_wand_2016/_data.py
+++ b/pystiche_papers/li_wand_2016/_data.py
@@ -1,4 +1,4 @@
-from typing import cast, Optional
+from typing import cast
 
 import torch
 from torch import nn

--- a/pystiche_papers/li_wand_2016/_data.py
+++ b/pystiche_papers/li_wand_2016/_data.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import cast, Optional
 
 import torch
 from torch import nn
@@ -6,6 +6,8 @@ from torchvision import transforms
 from torchvision.transforms import functional as F
 
 from pystiche import data
+
+from pystiche_papers.utils import license
 
 __all__ = ["images"]
 
@@ -70,6 +72,15 @@ class ResizeToVertEdge(nn.Module):
         return f"size={self.size}"
 
 
+def license_info(original: Optional[str] = None) -> str:
+    license_text = (
+        "The image is part of a repository that is published under the MIT License "
+        "(MIT) "
+        "(https://github.com/chuanli11/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/License#L1)."
+    )
+    return license(license_text, original=original)
+
+
 def image_note(url: str, mirror: bool = False) -> str:
     note = "The image is cropped"
     if mirror:
@@ -128,7 +139,7 @@ def images() -> data.DownloadableImageCollection:
             title="Blue Bottle",
             author="Christopher Michel (cmichel67)",
             date="02.09.2014",
-            license=data.NoLicense(),
+            license=license_info("https://www.flickr.com/photos/cmichel67/15112861945"),
             note=image_note("https://www.flickr.com/photos/cmichel67/15112861945"),
             md5="cb29d11ef6e1be7e074aa58700110e4f",
         ),

--- a/pystiche_papers/li_wand_2016/_data.py
+++ b/pystiche_papers/li_wand_2016/_data.py
@@ -77,9 +77,7 @@ def license(original: Optional[str] = None) -> str:
         "(https://github.com/chuanli11/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/License#L1)."
     )
     if original:
-        license_text = (
-            f"{license} The original was probably downloaded from {original}. "
-        )
+        license = f"{license} The original was probably downloaded from {original}. "
     return f"{license} Proceed at your own risk."
 
 

--- a/pystiche_papers/li_wand_2016/_data.py
+++ b/pystiche_papers/li_wand_2016/_data.py
@@ -7,8 +7,6 @@ from torchvision.transforms import functional as F
 
 from pystiche import data
 
-from pystiche_papers.utils import license
-
 __all__ = ["images"]
 
 
@@ -78,7 +76,12 @@ def license_info(original: Optional[str] = None) -> str:
         "(MIT) "
         "(https://github.com/chuanli11/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/License#L1)."
     )
-    return license(license_text, original=original)
+    if original:
+        license_text = (
+            f"{license_text} The original was probably downloaded from {original}. "
+            f"Proceed at your own risk."
+        )
+    return license_text
 
 
 def image_note(url: str, mirror: bool = False) -> str:

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -67,7 +67,7 @@ class ValidRandomCrop(nn.Module):
         )
 
 
-def license_info(original: Optional[str] = None, repository: str = "ulyanov") -> str:
+def license_info(repository: str = "ulyanov") -> str:
     if repository == "ulyanov":
         license_text = (
             "The image is part of a repository that is published under the Apache "
@@ -80,7 +80,7 @@ def license_info(original: Optional[str] = None, repository: str = "ulyanov") ->
             "research use only "
             "(https://github.com/jcjohnson/fast-neural-style/blob/master/README.md#license)."
         )
-    return license(license_text, original=original)
+    return license_text
 
 
 def content_transform(

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -32,12 +32,14 @@ LICENSE_ULYANOV = (
     "The image is part of a repository that is published under the Apache "
     "License"
     "(https://github.com/DmitryUlyanov/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/LICENSE#L1)."
+    "Proceed at your own risk."
 )
 
 LICENSE_JOHNSON = (
     "The image is part of a repository that is published for personal and "
     "research use only "
     "(https://github.com/jcjohnson/fast-neural-style/blob/master/README.md#license)."
+    "Proceed at your own risk."
 )
 
 

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -70,15 +70,15 @@ class ValidRandomCrop(nn.Module):
 def license_info(original: Optional[str] = None, repository: str = "ulyanov") -> str:
     if repository == "ulyanov":
         license_text = (
-            "The image is part of a repository that is published for personal and "
-            "research use only "
-            "(https://github.com/jcjohnson/fast-neural-style/blob/master/README.md#license)."
-        )
-    else:  # repository == "johnson"
-        license_text = (
             "The image is part of a repository that is published under the Apache "
             "License"
             "(https://github.com/DmitryUlyanov/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/LICENSE#L1)."
+        )
+    else:  # repository == "johnson"
+        license_text = (
+            "The image is part of a repository that is published for personal and "
+            "research use only "
+            "(https://github.com/jcjohnson/fast-neural-style/blob/master/README.md#license)."
         )
     return license(license_text, original=original)
 

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -17,6 +17,7 @@ from pystiche.data import (
 from pystiche.image import extract_edge_size, extract_image_size
 from pystiche_papers.utils import HyperParameters
 
+from pystiche_papers.utils import license
 from ..utils import OptionalGrayscaleToFakegrayscale
 from ._utils import hyper_parameters as _hyper_parameters
 
@@ -65,6 +66,22 @@ class ValidRandomCrop(nn.Module):
                 width=width,
             ),
         )
+
+
+def license_info(original: Optional[str] = None, repository: str = "ulyanov") -> str:
+    if repository == "ulyanov":
+        license_text = (
+            "The image is part of a repository that is published for personal and "
+            "research use only "
+            "(https://github.com/jcjohnson/fast-neural-style/blob/master/README.md#license)."
+        )
+    else: # repository == "johnson"
+        license_text = (
+            "The image is part of a repository that is published under the Apache "
+            "License"
+            "(https://github.com/DmitryUlyanov/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/LICENSE#L1)."
+        )
+    return license(license_text, original=original)
 
 
 def content_transform(
@@ -178,10 +195,12 @@ def images() -> DownloadableImageCollection:
     content_images = {
         "karya": DownloadableImage(
             urljoin(content_base_ulyanov, "karya.jpg"),
+            license=license_info(),
             md5="232b2f03a5d20c453a41a0e6320f27be",
         ),
         "tiger": DownloadableImage(
             urljoin(content_base_ulyanov, "tiger.jpg"),
+            license=license_info(),
             md5="e82bf374da425fb2c2e2a35a5a751989",
         ),
         "neckarfront": DownloadableImage(
@@ -203,10 +222,12 @@ def images() -> DownloadableImageCollection:
         ),
         "bird": DownloadableImage(
             urljoin(base_ulyanov_suppl, "bird.jpg"),
+            license=license_info(),
             md5="74dde9fad4749e7ff3cd4eca6cb43d0d",
         ),
         "kitty": DownloadableImage(
             urljoin(readme_ulyanov, "kitty.jpg"),
+            license=license_info(),
             md5="98262bd8f5ae25f8329158d2c2c66ad0",
         ),
     }
@@ -220,10 +241,12 @@ def images() -> DownloadableImageCollection:
     style_images = {
         "candy": DownloadableImage(
             urljoin(style_base_johnson, "candy.jpg"),
+            license=license_info(repository="johnson"),
             md5="00a0e3aa9775546f98abf6417e3cb478",
         ),
         "the_scream": DownloadableImage(
             urljoin(style_base_johnson, "the_scream.jpg"),
+            license=license_info(repository="johnson"),
             md5="619b4f42c84d2b62d3518fb20fa619c2",
         ),
         "jean_metzinger": DownloadableImage(
@@ -237,18 +260,22 @@ def images() -> DownloadableImageCollection:
         ),
         "mosaic": DownloadableImage(
             urljoin(base_ulyanov_suppl_style, "mosaic.jpg"),
+            license=license_info(),
             md5="4f05f1e12961cebf41bd372d909342b3",
         ),
         "pleades": DownloadableImage(
             urljoin(base_ulyanov_suppl_style, "pleades.jpg"),
+            license=license_info(),
             md5="6fc41ac30c2852a5454a0ead2f479dc9",
         ),
         "starry": DownloadableImage(
             urljoin(base_ulyanov_suppl_style, "starry.jpg"),
+            license=license_info(),
             md5="c6d94f7962466b2e80a64ae82523242a",
         ),
         "turner": DownloadableImage(
             urljoin(base_ulyanov_suppl_style, "turner.jpg"),
+            license=license_info(),
             md5="7fdd9603a5182dcef23d7fb1c5217888",
         ),
     }

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -28,6 +28,18 @@ __all__ = [
     "image_loader",
 ]
 
+LICENSE_ULYANOV = (
+    "The image is part of a repository that is published under the Apache "
+    "License"
+    "(https://github.com/DmitryUlyanov/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/LICENSE#L1)."
+)
+
+LICENSE_JOHNSON = (
+    "The image is part of a repository that is published for personal and "
+    "research use only "
+    "(https://github.com/jcjohnson/fast-neural-style/blob/master/README.md#license)."
+)
+
 
 class ValidRandomCrop(nn.Module):
     def __init__(self, size: Union[Tuple[int, int], int]):
@@ -65,22 +77,6 @@ class ValidRandomCrop(nn.Module):
                 width=width,
             ),
         )
-
-
-def license_info(repository: str = "ulyanov") -> str:
-    if repository == "ulyanov":
-        license_text = (
-            "The image is part of a repository that is published under the Apache "
-            "License"
-            "(https://github.com/DmitryUlyanov/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/LICENSE#L1)."
-        )
-    else:  # repository == "johnson"
-        license_text = (
-            "The image is part of a repository that is published for personal and "
-            "research use only "
-            "(https://github.com/jcjohnson/fast-neural-style/blob/master/README.md#license)."
-        )
-    return license_text
 
 
 def content_transform(
@@ -194,12 +190,12 @@ def images() -> DownloadableImageCollection:
     content_images = {
         "karya": DownloadableImage(
             urljoin(content_base_ulyanov, "karya.jpg"),
-            license=license_info(),
+            license=LICENSE_ULYANOV,
             md5="232b2f03a5d20c453a41a0e6320f27be",
         ),
         "tiger": DownloadableImage(
             urljoin(content_base_ulyanov, "tiger.jpg"),
-            license=license_info(),
+            license=LICENSE_ULYANOV,
             md5="e82bf374da425fb2c2e2a35a5a751989",
         ),
         "neckarfront": DownloadableImage(
@@ -221,12 +217,12 @@ def images() -> DownloadableImageCollection:
         ),
         "bird": DownloadableImage(
             urljoin(base_ulyanov_suppl, "bird.jpg"),
-            license=license_info(),
+            license=LICENSE_ULYANOV,
             md5="74dde9fad4749e7ff3cd4eca6cb43d0d",
         ),
         "kitty": DownloadableImage(
             urljoin(readme_ulyanov, "kitty.jpg"),
-            license=license_info(),
+            license=LICENSE_ULYANOV,
             md5="98262bd8f5ae25f8329158d2c2c66ad0",
         ),
     }
@@ -240,12 +236,12 @@ def images() -> DownloadableImageCollection:
     style_images = {
         "candy": DownloadableImage(
             urljoin(style_base_johnson, "candy.jpg"),
-            license=license_info(repository="johnson"),
+            license=LICENSE_JOHNSON,
             md5="00a0e3aa9775546f98abf6417e3cb478",
         ),
         "the_scream": DownloadableImage(
             urljoin(style_base_johnson, "the_scream.jpg"),
-            license=license_info(repository="johnson"),
+            license=LICENSE_JOHNSON,
             md5="619b4f42c84d2b62d3518fb20fa619c2",
         ),
         "jean_metzinger": DownloadableImage(
@@ -259,22 +255,22 @@ def images() -> DownloadableImageCollection:
         ),
         "mosaic": DownloadableImage(
             urljoin(base_ulyanov_suppl_style, "mosaic.jpg"),
-            license=license_info(),
+            license=LICENSE_ULYANOV,
             md5="4f05f1e12961cebf41bd372d909342b3",
         ),
         "pleades": DownloadableImage(
             urljoin(base_ulyanov_suppl_style, "pleades.jpg"),
-            license=license_info(),
+            license=LICENSE_ULYANOV,
             md5="6fc41ac30c2852a5454a0ead2f479dc9",
         ),
         "starry": DownloadableImage(
             urljoin(base_ulyanov_suppl_style, "starry.jpg"),
-            license=license_info(),
+            license=LICENSE_ULYANOV,
             md5="c6d94f7962466b2e80a64ae82523242a",
         ),
         "turner": DownloadableImage(
             urljoin(base_ulyanov_suppl_style, "turner.jpg"),
-            license=license_info(),
+            license=LICENSE_ULYANOV,
             md5="7fdd9603a5182dcef23d7fb1c5217888",
         ),
     }

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -17,7 +17,6 @@ from pystiche.data import (
 from pystiche.image import extract_edge_size, extract_image_size
 from pystiche_papers.utils import HyperParameters
 
-from pystiche_papers.utils import license
 from ..utils import OptionalGrayscaleToFakegrayscale
 from ._utils import hyper_parameters as _hyper_parameters
 
@@ -75,7 +74,7 @@ def license_info(original: Optional[str] = None, repository: str = "ulyanov") ->
             "research use only "
             "(https://github.com/jcjohnson/fast-neural-style/blob/master/README.md#license)."
         )
-    else: # repository == "johnson"
+    else:  # repository == "johnson"
         license_text = (
             "The image is part of a repository that is published under the Apache "
             "License"

--- a/pystiche_papers/utils/misc.py
+++ b/pystiche_papers/utils/misc.py
@@ -40,7 +40,6 @@ __all__ = [
     "str_to_bool",
     "load_urls_from_csv",
     "select_url_from_csv",
-    "license",
 ]
 
 

--- a/pystiche_papers/utils/misc.py
+++ b/pystiche_papers/utils/misc.py
@@ -241,12 +241,7 @@ def select_url_from_csv(
         raise RuntimeError(msg) from error
 
 
-def license(original_license: str, original: Optional[str] = None) -> str:
-    license = (
-        f"The image is part of a repository that is published for academic and "
-        f"non-commercial use only "
-        f"({original_license})."
-    )
+def license(license: str, original: Optional[str] = None) -> str:
     if original:
         license = (
             f"{license} The original was probably downloaded from {original}. "

--- a/pystiche_papers/utils/misc.py
+++ b/pystiche_papers/utils/misc.py
@@ -40,6 +40,7 @@ __all__ = [
     "str_to_bool",
     "load_urls_from_csv",
     "select_url_from_csv",
+    "license",
 ]
 
 
@@ -238,3 +239,18 @@ def select_url_from_csv(
             f"{fieldname}: {value}" for fieldname, value in zip(fieldnames, config)
         )
         raise RuntimeError(msg) from error
+
+
+def license(original_license: str, original: Optional[str] = None) -> str:
+    license = (
+        f"The image is part of a repository that is published for academic and "
+        f"non-commercial use only "
+        f"({original_license})."
+    )
+    if original:
+        license = (
+            f"{license} The original was probably downloaded from {original}. "
+            f"Proceed at your own risk."
+        )
+
+    return license

--- a/pystiche_papers/utils/misc.py
+++ b/pystiche_papers/utils/misc.py
@@ -239,13 +239,3 @@ def select_url_from_csv(
             f"{fieldname}: {value}" for fieldname, value in zip(fieldnames, config)
         )
         raise RuntimeError(msg) from error
-
-
-def license(license: str, original: Optional[str] = None) -> str:
-    if original:
-        license = (
-            f"{license} The original was probably downloaded from {original}. "
-            f"Proceed at your own risk."
-        )
-
-    return license


### PR DESCRIPTION
In [#283](https://github.com/pystiche/papers/pull/283), a licence information for the images of `gatys_et_al_2017` from the original repository has been introduced. This information is generally useful for replications in which the images from the original repository are used. 

For this reason, this PR integrates this licence information for all current replications.

