### PR TITLE
Fix partially wrong num_batches in johnson_alahi_li_2016 training

### DIFF
--- a/pystiche_papers/johnson_alahi_li_2016/_data.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_data.py
@@ -224,7 +224,7 @@ def image_loader(
         hyper_parameters = _hyper_parameters()
     return DataLoader(
         dataset,  # type: ignore[arg-type]
-        batch_sampler=batch_sampler(dataset),
+        batch_sampler=batch_sampler(dataset, hyper_parameters=hyper_parameters),
         num_workers=hyper_parameters.batch_sampler.batch_size,
         pin_memory=pin_memory,
     )

--- a/replication/johnson_alahi_li_2016/training.py
+++ b/replication/johnson_alahi_li_2016/training.py
@@ -86,10 +86,6 @@ def adapted_hyper_parameters(impl_params, instance_norm, style):
 
 def main(args):
     dataset = paper.dataset(args.dataset_dir, impl_params=args.impl_params)
-    content_image_loader = paper.image_loader(
-        dataset,
-        pin_memory=str(args.device).startswith("cuda"),
-    )
 
     for style in args.style:
         style_image = read_style_image(
@@ -98,6 +94,12 @@ def main(args):
 
         hyper_parameters = adapted_hyper_parameters(
             args.impl_params, args.instance_norm, style
+        )
+
+        content_image_loader = paper.image_loader(
+            dataset,
+            hyper_parameters=hyper_parameters,
+            pin_memory=str(args.device).startswith("cuda"),
         )
 
         transformer = paper.training(


### PR DESCRIPTION
As mentioned in [#292](https://github.com/pystiche/papers/issues/292) this PR corrects the bug with the adapted hyperparameters. The hyperparameters are now passed through.